### PR TITLE
Added knowledge list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ Repository for recording knowledge about things I'm learning and things I'm inte
 
 ## web ring
 
-- https://github.com/yoshuawuyts/knowledge
-- https://github.com/sotayamashita/knowledge
-- https://github.com/theatlasroom/tidbits
-- https://github.com/sotojuan/knowledge
+There are a few other knowledge lists. Join us here: https://github.com/RichardLitt/meta-knowledge/blob/master/README.md
 
 ## License
 


### PR DESCRIPTION
So, I really like the term web ring! A lot! But I'm not sure it is the best way to show this information. 

I've made a meta list of knowledge repos, because I have one too, and I didn't want to make everyone PR all of these knowledge lists. Having one place to have the lists makes more sense.

What do you think?